### PR TITLE
Add participant deletion route and button

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Document;
+use App\Models\DocumentParticipant;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -67,6 +68,17 @@ class DocumentController extends Controller
         $request->validate(['name' => 'required|string|max:255', 'email' => 'required|email|max:255']);
         $document->participants()->create(['name' => $request->name, 'email' => $request->email, 'token' => Str::uuid()]);
         return back()->with('success', 'تمت إضافة الموقّع بنجاح.');
+    }
+
+    /**
+     * Delete a participant from the document.
+     */
+    public function deleteParticipant(DocumentParticipant $participant)
+    {
+        $document = $participant->document;
+        if (auth()->id() !== $document->user_id) { abort(403); }
+        $participant->delete();
+        return back()->with('success', 'تم حذف الموقّع بنجاح.');
     }
 
     /**

--- a/resources/views/documents/show.blade.php
+++ b/resources/views/documents/show.blade.php
@@ -68,7 +68,18 @@
                     <hr class="mb-4">
                     <div class="space-y-3">
                         @forelse ($document->participants as $participant)
-                            <div class="flex items-center p-2 rounded-lg" :class="{ 'bg-blue-100 ring-2 ring-blue-400': selectedParticipantId == {{ $participant->id }} }"><label class="flex items-center w-full cursor-pointer"><input type="radio" name="selected_participant" value="{{ $participant->id }}" x-model.number="selectedParticipantId" class="h-4 w-4"><span class="mr-3" style="width: 15px; height: 15px; border-radius: 50%; background-color: {{ ['#3B82F6', '#F59E0B', '#10B981', '#EF4444', '#8B5CF6'][$loop->index % 5] }};"></span><span>{{ $participant->name }}</span></label></div>
+                            <div class="flex items-center p-2 rounded-lg" :class="{ 'bg-blue-100 ring-2 ring-blue-400': selectedParticipantId == {{ $participant->id }} }">
+                                <label class="flex items-center flex-1 cursor-pointer">
+                                    <input type="radio" name="selected_participant" value="{{ $participant->id }}" x-model.number="selectedParticipantId" class="h-4 w-4">
+                                    <span class="mr-3" style="width: 15px; height: 15px; border-radius: 50%; background-color: {{ ['#3B82F6', '#F59E0B', '#10B981', '#EF4444', '#8B5CF6'][$loop->index % 5] }};"></span>
+                                    <span>{{ $participant->name }}</span>
+                                </label>
+                                <form action="{{ route('documents.participants.destroy', $participant) }}" method="POST" class="ml-2" onsubmit="return confirm('هل أنت متأكد من الحذف؟');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-red-600 hover:underline">حذف</button>
+                                </form>
+                            </div>
                         @empty
                             <p class="text-center text-gray-500">الرجاء إضافة موقّعين أولاً.</p>
                         @endforelse

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // المستندات
     Route::resource('documents', DocumentController::class)->except(['index']);
     Route::post('/documents/{document}/participants', [DocumentController::class, 'addParticipant'])->name('documents.participants.store');
+    Route::delete('/documents/participants/{participant}', [DocumentController::class, 'deleteParticipant'])->name('documents.participants.destroy');
     Route::get('/documents/{document}/download', [DocumentController::class, 'download'])->name('documents.download');
     Route::patch('/documents/{document}/fields', [DocumentController::class, 'saveFields'])->name('documents.fields.update');
     Route::post('/documents/{document}/send', [DocumentController::class, 'send'])->name('documents.send');


### PR DESCRIPTION
## Summary
- add route for removing document participants
- implement `deleteParticipant` in `DocumentController`
- show delete button for participants on document page

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685a77baacec83308b0d855060349729