### PR TITLE
Fix missing div closure in document view

### DIFF
--- a/resources/views/documents/show.blade.php
+++ b/resources/views/documents/show.blade.php
@@ -181,4 +181,5 @@
                 }));
             });
         </script>
+    </div>
     </x-app-layout>


### PR DESCRIPTION
## Summary
- close `<div class="py-12">` in `documents/show` view
- ensure layout has a single closing tag

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a7b9814f883308915298fc5c26738