### PR TITLE
Add PDF.js multi-page editor

### DIFF
--- a/resources/views/templates/edit.blade.php
+++ b/resources/views/templates/edit.blade.php
@@ -6,30 +6,17 @@
     </x-slot>
 
     <!-- The main component that controls everything -->
-    <div class="py-12" 
+    <div class="py-12"
          x-data="templateEditor(
-            '{{ route('templates.update', $template) }}', 
+            '{{ route('templates.update', $template) }}',
+            '{{ $base64Pdf }}',
             {{ json_encode($template->fields ?? []) }}
          )">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-3 gap-6" dir="rtl">
             
             <!-- Main Area: PDF Viewer with Interactive Fields Layer -->
-            <div class="lg:col-span-2 bg-gray-200 relative shadow-sm sm:rounded-lg" x-ref="container">
-                <!-- Fields Layer -->
-                <div class="absolute top-0 left-0 w-full h-full" :class="{ 'pointer-events-none': dragging || resizing }">
-                    <template x-for="field in fields" :key="field.id">
-                        <div
-                            class="absolute border-2 border-dashed cursor-move flex items-center justify-center text-xs font-bold text-white rounded-sm pointer-events-auto"
-                            :style="`left: ${field.x}px; top: ${field.y}px; width: ${field.width}px; height: ${field.height}px; background-color: ${getRoleColor(field.role_id, 0.7)}; border-color: ${getRoleColor(field.role_id, 1)};`"
-                            @mousedown.prevent="startDrag($event, field)"
-                        >
-                            <span class="bg-black bg-opacity-50 p-1 rounded" x-text="getFieldLabel(field)"></span>
-                            <div class="absolute -bottom-1 -right-1 w-4 h-4 cursor-nwse-resize pointer-events-auto bg-white border-2 rounded-full" :style="`border-color: ${getRoleColor(field.role_id, 1)}`" @mousedown.prevent.stop="startResize($event, field)"></div>
-                        </div>
-                    </template>
-                </div>
-                <!-- PDF Iframe Layer -->
-                <iframe src="data:application/pdf;base64,{{ $base64Pdf }}" width="100%" height="750px" class="relative"></iframe>
+            <div class="lg:col-span-2 bg-gray-200 relative shadow-sm sm:rounded-lg overflow-y-auto" x-ref="container" @scroll="onScroll">
+                <div class="space-y-4 p-4" x-ref="pages"></div>
             </div>
 
             <!-- Sidebar -->
@@ -72,9 +59,11 @@
             </div>
         </div>
         
+        <script src="{{ asset('libs/pdf.min.js') }}"></script>
+        <script src="{{ asset('libs/pdf.worker.min.js') }}"></script>
         <script>
             document.addEventListener('alpine:init', () => {
-                Alpine.data('templateEditor', (saveUrl, initialFields) => ({
+                Alpine.data('templateEditor', (saveUrl, pdfData, initialFields) => ({
                     fields: initialFields || [],
                     signerRoles: [
                         { id: 1, name: 'الموقّع الأول' },
@@ -83,8 +72,15 @@
                     ],
                     selectedRoleId: 1,
                     saving: false, dragging: false, resizing: false, activeField: null,
+                    pdfData: pdfData,
+                    currentPage: 1,
+                    numPages: 0,
                     
-                    init() { this.fields.forEach((field, i) => field.id = field.id || Date.now() + i); },
+                    init() {
+                        this.fields.forEach((field, i) => field.id = field.id || Date.now() + i);
+                        this.renderPdf();
+                        this.$watch('fields', () => this.updateFields(), {deep: true});
+                    },
                     getRoleColor(id, opacity=1) {
                         const colors = ['#3B82F6','#F59E0B','#10B981','#EF4444','#8B5CF6'];
                         const hex = colors[((id || 1) - 1) % colors.length];
@@ -96,22 +92,99 @@
                         const typeLabels = {'signature':'توقيع','text':'نص','date':'تاريخ'};
                         return `${typeLabels[field.type] || field.type} - ${role ? role.name : 'غير محدد'}`;
                     },
+                    renderPdf() {
+                        const container = this.$refs.pages;
+                        const raw = atob(this.pdfData);
+                        const bytes = new Uint8Array(raw.length);
+                        for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+                        pdfjsLib.GlobalWorkerOptions.workerSrc = '/libs/pdf.worker.min.js';
+                        pdfjsLib.getDocument({data: bytes}).promise.then(pdf => {
+                            this.numPages = pdf.numPages;
+                            const promises = [];
+                            for (let n = 1; n <= pdf.numPages; n++) {
+                                promises.push(pdf.getPage(n).then(page => {
+                                    const viewport = page.getViewport({scale:1});
+                                    const scale = container.clientWidth / viewport.width;
+                                    const vp = page.getViewport({scale});
+                                    const canvas = document.createElement('canvas');
+                                    canvas.width = vp.width;
+                                    canvas.height = vp.height;
+                                    const ctx = canvas.getContext('2d');
+                                    const div = document.createElement('div');
+                                    div.style.position = 'relative';
+                                    div.style.marginBottom = '20px';
+                                    div.dataset.page = n;
+                                    div.appendChild(canvas);
+                                    const overlay = document.createElement('div');
+                                    overlay.className = 'absolute top-0 left-0 w-full h-full';
+                                    overlay.dataset.overlay = n;
+                                    div.appendChild(overlay);
+                                    container.appendChild(div);
+                                    return page.render({canvasContext: ctx, viewport: vp}).promise;
+                                }));
+                            }
+                            return Promise.all(promises);
+                        }).then(() => this.updateFields());
+                    },
+                    onScroll() {
+                        const container = this.$refs.container;
+                        const center = container.getBoundingClientRect().top + container.clientHeight / 2;
+                        const pages = Array.from(container.querySelectorAll('[data-page]'));
+                        for (const p of pages) {
+                            const rect = p.getBoundingClientRect();
+                            if (rect.top <= center && rect.bottom >= center) {
+                                this.currentPage = parseInt(p.dataset.page);
+                                break;
+                            }
+                        }
+                    },
+                    updateFields() {
+                        const container = this.$refs.container;
+                        const overlays = container.querySelectorAll('[data-overlay]');
+                        overlays.forEach(o => o.innerHTML = '');
+                        this.fields.forEach(field => {
+                            const overlay = container.querySelector(`[data-overlay='${field.page}']`);
+                            if(!overlay) return;
+                            const el = document.createElement('div');
+                            el.className = 'absolute border-2 border-dashed cursor-move flex items-center justify-center text-xs font-bold text-white rounded-sm pointer-events-auto';
+                            el.style.left = field.x + 'px';
+                            el.style.top = field.y + 'px';
+                            el.style.width = field.width + 'px';
+                            el.style.height = field.height + 'px';
+                            el.style.backgroundColor = this.getRoleColor(field.role_id,0.7);
+                            el.style.borderColor = this.getRoleColor(field.role_id,1);
+                            el.addEventListener('mousedown', (e)=>{e.preventDefault(); this.startDrag(e, field);});
+                            const label = document.createElement('span');
+                            label.className = 'bg-black bg-opacity-50 p-1 rounded';
+                            label.textContent = this.getFieldLabel(field);
+                            el.appendChild(label);
+                            const resize = document.createElement('div');
+                            resize.className = 'absolute -bottom-1 -right-1 w-4 h-4 cursor-nwse-resize pointer-events-auto bg-white border-2 rounded-full';
+                            resize.style.borderColor = this.getRoleColor(field.role_id,1);
+                            resize.addEventListener('mousedown', (e)=>{e.preventDefault(); e.stopPropagation(); this.startResize(e, field);});
+                            el.appendChild(resize);
+                            overlay.appendChild(el);
+                        });
+                    },
                     addField(type) {
                         if (!this.selectedRoleId) { alert('الرجاء تحديد دور الموقّع أولاً.'); return; }
-                        this.fields.push({ id: Date.now(), type: type, role_id: this.selectedRoleId, page: 1, x: 30, y: 30, width: 150, height: 50 });
+                        this.fields.push({ id: Date.now(), type: type, role_id: this.selectedRoleId, page: this.currentPage, x: 30, y: 30, width: 150, height: 50 });
                     },
                     startDrag(event, field) {
                         if(this.resizing) return; this.dragging = true; this.activeField = field;
-                        const containerRect = this.$refs.container.getBoundingClientRect();
-                        let offsetX = event.clientX - containerRect.left - field.x;
-                        let offsetY = event.clientY - containerRect.top - field.y;
-                        const moveHandler = (e) => { if (!this.dragging) return; field.x = e.clientX - containerRect.left - offsetX; field.y = e.clientY - containerRect.top - offsetY; };
+                        const pageEl = event.target.closest('[data-page]');
+                        const rect = pageEl.getBoundingClientRect();
+                        let offsetX = event.clientX - rect.left - field.x;
+                        let offsetY = event.clientY - rect.top - field.y;
+                        const moveHandler = (e) => { if (!this.dragging) return; field.x = e.clientX - rect.left - offsetX; field.y = e.clientY - rect.top - offsetY; };
                         const upHandler = () => { this.dragging = false; this.activeField = null; document.removeEventListener('mousemove', moveHandler); document.removeEventListener('mouseup', upHandler); };
                         document.addEventListener('mousemove', moveHandler);
                         document.addEventListener('mouseup', upHandler);
                     },
                     startResize(event, field) {
                         this.resizing = true; this.activeField = field;
+                        const pageEl = event.target.closest('[data-page]');
+                        const rect = pageEl.getBoundingClientRect();
                         let initialWidth = field.width; let initialHeight = field.height;
                         let initialMouseX = event.clientX; let initialMouseY = event.clientY;
                         const moveHandler = (e) => { if (!this.resizing) return; field.width = Math.max(50, initialWidth + (e.clientX - initialMouseX)); field.height = Math.max(40, initialHeight + (e.clientY - initialMouseY)); };


### PR DESCRIPTION
## Summary
- integrate PDF.js viewer in document and template editors
- allow fields to track page number and add via scroll position
- show each page separately and bind field overlay to the page
- adjust dragging/resizing relative to page

## Testing
- `composer test` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685a6b48599c8330b53191f9928d459d