### PR TITLE
Add page navigation to PDF editors

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\SignatureRequestMail;
+use setasign\Fpdi\Tcpdf\Fpdi;
 
 class DocumentController extends Controller
 {
@@ -33,10 +34,15 @@ class DocumentController extends Controller
         $fileContent = \Illuminate\Support\Facades\Storage::disk('private')->get($filePath);
         $base64Pdf = base64_encode($fileContent);
 
+        // Determine the number of pages in the PDF
+        $pdf = new Fpdi();
+        $numPages = $pdf->setSourceFile(Storage::disk('private')->path($filePath));
+
         // Pass both the document and the base64 data to the view
         return view('documents.show', [
-            'document' => $document,
-            'base64Pdf' => $base64Pdf,
+            'document'   => $document,
+            'base64Pdf'  => $base64Pdf,
+            'numPages'   => $numPages,
         ]);
     }
     

--- a/app/Http/Controllers/TemplateController.php
+++ b/app/Http/Controllers/TemplateController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Template;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use setasign\Fpdi\Tcpdf\Fpdi;
 
 class TemplateController extends Controller
 {
@@ -58,9 +59,14 @@ class TemplateController extends Controller
         $fileContent = Storage::disk('private')->get($template->original_file_path);
         $base64Pdf = base64_encode($fileContent);
 
+        // Determine total pages of the template PDF
+        $pdf = new Fpdi();
+        $numPages = $pdf->setSourceFile(Storage::disk('private')->path($template->original_file_path));
+
         return view('templates.edit', [
-            'template' => $template,
+            'template'  => $template,
             'base64Pdf' => $base64Pdf,
+            'numPages'  => $numPages,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- compute PDF page count in controllers
- show page navigation with current/total count in template & document editors
- add JS logic to change pages and place fields on the selected page

## Testing
- `composer test` *(fails: composer not installed)*
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685a7c50d6d483308bbfcd6f4567906c